### PR TITLE
Fix SonarCloud analysis for fork pull requests

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -10,7 +10,7 @@ on:
   push:
     branches:
       - main
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened]
 jobs:
   build:


### PR DESCRIPTION
Enhance SonarCloud workflow security for fork PRs
- Switch from pull_request to pull_request_target for proper secret access